### PR TITLE
Fix issue with simultaneously requests for the same schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+/.idea

--- a/registry.js
+++ b/registry.js
@@ -6,9 +6,90 @@ const https = require('http');
 
 const avsc = require('avsc');
 
+function fetchSchema(transport, protocol, host, port, schemaId) {
+  return new Promise((resolve, reject) => {
+    transport.get(`${protocol}//${host}:${port}/schemas/ids/${schemaId}`, (res) => {
+      let data = '';
+      res.on('data', (d) => {
+        data += d;
+      });
+      res.on('error', (e) => {
+        reject(e);
+      });
+      res.on('end', () => {
+        if (res.statusCode !== 200) {
+          const error = JSON.parse(data);
+          return reject(new Error(`Schema registry error: ${error.error_code} - ${error.message}`));
+        }
+
+        const schema = JSON.parse(data).schema;
+        resolve(schema);
+      });
+    });
+  });
+}
+
+function pushSchema(transport, protocol, host, port, path, topic, schemaString) {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({schema: schemaString});
+    const req = transport.request({
+      host: `${host}`,
+      port: port,
+      method: 'POST',
+      path: `${path}subjects/${topic}-value/versions`,
+      headers: {
+        'Content-Type': 'application/vnd.schemaregistry.v1+json',
+        'Content-Length': Buffer.byteLength(body),
+      },
+    }, (res) => {
+      let data = '';
+      res.on('data', (d) => {
+        data += d;
+      });
+      res.on('error', (e) => {
+        reject(e);
+      });
+      res.on('end', () => {
+        if (res.statusCode !== 200) {
+          const error = JSON.parse(data);
+          return reject(new Error(`Schema registry error: ${error.error_code} - ${error.message}`));
+        }
+
+        const resp = JSON.parse(data);
+
+        resolve(resp.id);
+      });
+    });
+    req.write(body);
+    req.end();
+  });
+}
+
+class SchemaCache {
+  constructor() {
+    this.schemasById = new Map();
+    this.schemasBySchema = new Map();
+  }
+
+  set(schemaId, schema) {
+    this.schemasById.set(schemaId, schema);
+    if (!(schema instanceof Promise)) {
+      this.schemasBySchema.set(JSON.stringify(schema), schemaId);
+    }
+  }
+
+  getById(schemaId) {
+    return this.schemasById.get(schemaId);
+  }
+
+  getBySchema(schema) {
+    return this.schemasBySchema.get(JSON.stringify(schema));
+  }
+}
+
 function schemas(registryUrl) {
   const parsed = url.parse(registryUrl);
-  const schemas = {};
+  const schemas = new SchemaCache();
   const registry = {
     protocol: parsed.protocol,
     host: parsed.hostname,
@@ -16,95 +97,57 @@ function schemas(registryUrl) {
     path: parsed.path,
   };
   const protocol = registry.protocol === 'https:' ? https : http;
-  
-  const decodeMessage = (msg) => new Promise((resolve, reject) => {
+
+  const decodeMessage = (msg) => {
+    let schemaId;
+
+    return new Promise((resolve, reject) => {
       if (msg.readUInt8(0) !== 0) {
         return reject(new Error(`Message doesn't contain schema identifier byte.`));
       }
+      schemaId = msg.readUInt32BE(1);
+      let promise = schemas.getById(schemaId);
 
-      const schemaId = msg.readUInt32BE(1);
-      for (let [id, schema] of Object.entries(schemas)) {
-        if (parseInt(id, 10) === schemaId) {
-          return resolve(schema);
-        }
+      if (promise) {
+        return resolve(promise);
       }
 
-      protocol.get(`${parsed.protocol}//${parsed.host}/schemas/ids/${schemaId}`, (res) => {
-        let data = '';
-        res.on('data', (d) => {
-          data += d;
-        });
-        res.on('error', (e) => {
-          reject(e);
-        });
-        res.on('end', () => {
-          if (res.statusCode !== 200) {
-            const error = JSON.parse(data);
-            return reject(new Error(`Schema registry error: ${error.error_code} - ${error.message}`));
-          }
-
-          const schema = JSON.parse(data).schema;
-          schemas[schemaId] = schema;
-          resolve(schema);
-        });
-
-      });
+      promise = fetchSchema(protocol, registry.protocol, registry.host, registry.port, schemaId);
+      schemas.set(schemaId, promise);
+      promise.then(result => {
+        schemas.set(schemaId, result);
+      }).catch(reject);
+      return resolve(promise);
     })
-    .then((schema) => {
-      return avsc.parse(schema).fromBuffer(msg.slice(5));
-    });
-    
-  const encodeMessage = (topic, schema, msg) => (() => new Promise((resolve, reject) => {
-      const schemaString = JSON.stringify(schema);
-      for (let [id, cSchema] of Object.entries(schemas)) {
-        if (schema === cSchema) {
-          return resolve(id);
-        }
-      }
-
-      const req = protocol.request({
-        host: `${registry.host}`,
-        port: registry.port,
-        method: 'POST',
-        path: `${parsed.path}subjects/${topic}-value/versions`,
-        headers: {
-            'Content-Type': 'application/vnd.schemaregistry.v1+json',
-            'Content-Length': Buffer.byteLength(JSON.stringify({schema: schemaString})),
-        },
-      }, (res) => {
-        let data = '';
-        res.on('data', (d) => {
-          data += d;
-        });
-        res.on('error', (e) => {
-          reject(e);
-        });
-        res.on('end', () => {
-          if (res.statusCode !== 200) {
-            const error = JSON.parse(data);
-            return reject(new Error(`Schema registry error: ${error.error_code} - ${error.message}`));
-          }
-
-          const resp = JSON.parse(data);
-
-          schemas[resp.id] = schema;
-
-          resolve(resp.id);
-        });
+      .then((schema) => {
+        return avsc.parse(schema).fromBuffer(msg.slice(5));
       });
-      req.write(JSON.stringify({schema: schemaString}));
-      req.end();
-    }))()
+  };
+
+  const encodeMessage = (topic, schema, msg) => (() => new Promise((resolve, reject) => {
+    const schemaString = JSON.stringify(schema);
+    let id = schemas.getBySchema(schema);
+    if (id) {
+      return resolve(id)
+    }
+
+    const promise = pushSchema(protocol, registry.protocol, registry.host, registry.port, parsed.path, topic, schemaString);
+    promise.then(id => {
+      schemas.set(id, schema);
+      return schema;
+    }).catch(reject);
+    return resolve(promise);
+  }))()
     .then((schemaId) => {
       const encodedMessage = avsc.parse(schema).toBuffer(msg);
 
-      const message = new Buffer(encodedMessage.length + 5);
+      const message = Buffer.alloc(encodedMessage.length + 5);
       message.writeUInt8(0);
       message.writeUInt32BE(schemaId, 1);
       encodedMessage.copy(message, 5);
       return message;
     });
-    
+
   return {encodeMessage, decodeMessage};
 };
 


### PR DESCRIPTION
During my work with the package, I faced with an issue with exceeding the limit of opened connections and `socket hangup` from a registry side.

The problem occurs when Kafka consumer receives a lot of messages from a topic with the same schema simultaneously (well, almost simultaneously :-),)

E.g.
I'm calling the `decodeMessage` function for the same schema twice without waiting for the response from the first invoking.
At the time, when `decodeMessage` executes the second time the request already fired, but the answer didn't come, the second call of `decodeMessage` fires a new request for the same schema.
When we are talking about two simultaneously calls - this is not an issue. But in my case, I saw up to 500 opened connection at the same time. 
This could create a small DOS attack to the schema registry server.