### PR TITLE
Get schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Confluent Schema Registry implementation to easily serialize and deserialize kaf
 ```
 const registry = require('avro-schema-registry')('https://host.com:8081');
 
-const schema = {type: 'string'};
+const schema = {type: 'string'}; // schema can also have multiple fields, see Schema Object
 const message = 'test message';
 
 registry.encodeMessage('topic', schema, message)
@@ -69,6 +69,23 @@ Parameters:
 
 Encodes a message object into an avro encoded buffer.
 
+### Schema Object
+
+Schema can be a single key:value pair like so
+```
+const schema = {type: 'string'};
+```
+and can also have multiple properties according to https://docs.confluent.io/current/schema-registry/docs/
+
+```
+const schm = {
+  type: 'record',
+  name: 'test',
+  fields: [
+    {name: 'name', type: 'string'},
+  ]
+};
+```
 ## encodeById
 Parameters:
 - id: schema id in the registry

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Confluent Schema Registry implementation to easily serialize and deserialize kaf
 ```
 const registry = require('avro-schema-registry')('https://host.com:8081');
 
-const schema = {type: 'string'}; // schema can also have multiple fields, see Schema Object
+const schema = {type: 'string'};
 const message = 'test message';
 
 registry.encodeMessage('topic', schema, message)
@@ -69,23 +69,6 @@ Parameters:
 
 Encodes a message object into an avro encoded buffer.
 
-### Schema Object
-
-Schema can be a single key:value pair like so
-```
-const schema = {type: 'string'};
-```
-and can also have multiple properties according to https://docs.confluent.io/current/schema-registry/docs/
-
-```
-const schm = {
-  type: 'record',
-  name: 'test',
-  fields: [
-    {name: 'name', type: 'string'},
-  ]
-};
-```
 ## encodeById
 Parameters:
 - id: schema id in the registry

--- a/lib/decode-function.js
+++ b/lib/decode-function.js
@@ -4,7 +4,7 @@ const avsc = require('avsc');
 
 const fetchSchema = require('./fetch-schema');
 
-module.exports = (registry) => (obj) => new Promise((resolve, reject) => {
+module.exports = (registry) => (obj, return_schema = false) => new Promise((resolve, reject) => {
   let schemaId;
   
   if (obj.readUInt8(0) !== 0) {
@@ -26,4 +26,9 @@ module.exports = (registry) => (obj) => new Promise((resolve, reject) => {
       .catch(reject);
 
     return resolve(promise);
-}).then((schema) => avsc.parse(schema).fromBuffer(obj.slice(5)));
+}).then((schema) => {
+  if(return_schema) { return schema }
+  
+  avsc.parse(schema).fromBuffer(obj.slice(5))
+  
+});

--- a/lib/decode-function.js
+++ b/lib/decode-function.js
@@ -27,8 +27,8 @@ module.exports = (registry) => (obj, return_schema = false) => new Promise((reso
 
     return resolve(promise);
 }).then((schema) => {
-  if(return_schema) { return schema }
-  
+  if(return_schema) { return avsc.parse(schema) }
+
   avsc.parse(schema).fromBuffer(obj.slice(5))
   
 });

--- a/registry.js
+++ b/registry.js
@@ -9,6 +9,7 @@ const SchemaCache = require('./lib/schema-cache');
 const decodeFunction = require('./lib/decode-function');
 const encodeFunction = require('./lib/encode-function');
 
+
 function schemas(registryUrl) {
   const parsed = url.parse(registryUrl);
   const registry = {
@@ -20,6 +21,7 @@ function schemas(registryUrl) {
   };
 
   const decode = decodeFunction(registry)
+  const getSchemabyMessage = decodeFunction(registry, true)
   const encodeKey = encodeFunction.bySchema('key', registry);
   const encodeMessage = encodeFunction.bySchema('value', registry);
   const encodeById = encodeFunction.byId(registry);
@@ -30,6 +32,7 @@ function schemas(registryUrl) {
     encodeById,
     encodeKey,
     encodeMessage,
+    getSchemabyMessage
   };
 };
 


### PR DESCRIPTION
I need to parse once and batch handle thousands of messages, and parsing the schema and decoding at the same time proved to be inefficient. Adding this function allows me to grab the schema once by ID and then iterate over messages to decode it. 

This was the quickest method I came up with, however I think your internal schema cache should be extended to cache the already parsed schema, and decode message could be converted to check for a parsed schema on each iteration. 

I don't believe this needs to be merged in as its incomplete, but wanted to use this to start the conversation of caching the schema. 