### PR TITLE
store parsed schema in cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ The module exports one function only, which expects a `url` parameter, which is 
 
 Every method returns a Promise.
 
-Every method uses an internal cache to store already retrieved schemas and if the same id or schema is used again it won't perform another network call.
+Every method uses an internal cache to store already retrieved schemas and if the same id or schema is used again it won't perform another network call. Schemas are cached with their parsing options.
 
 ## decode
 Parameters:
 - msg: object to decode
+- parseOptions: parsiong options to pass to `avsc.parse`, default: `null`
 
 Decodes an avro encoded buffer into a javascript object.
 
@@ -58,6 +59,7 @@ Parameters:
 - topic: the topic to register the schema, if it doesn't exist already in the registry. The schema will be put under the subject `${topic}-key`
 - schema: object representing an avro schema
 - msg: message object to be encoded
+- parseOptions: parsiong options to pass to `avsc.parse`, default: `null`
 
 Encodes an object into an avro encoded buffer.
 
@@ -66,6 +68,7 @@ Parameters:
 - topic: the topic to register the schema, if it doesn't exist already in the registry. The schema will be put under the subject `${topic}-value`
 - schema: object representing an avro schema
 - msg: message object to be encoded
+- parseOptions: parsiong options to pass to `avsc.parse`, default: `null`
 
 Encodes a message object into an avro encoded buffer.
 
@@ -73,6 +76,7 @@ Encodes a message object into an avro encoded buffer.
 Parameters:
 - id: schema id in the registry
 - msg: message object to be encoded
+- parseOptions: parsiong options to pass to `avsc.parse`, default: `null`
 
 Encodes a message object into an avro encoded buffer by fetching the schema from the registry.
 

--- a/lib/decode-function.js
+++ b/lib/decode-function.js
@@ -2,7 +2,7 @@
 
 const fetchSchema = require('./fetch-schema');
 
-module.exports = (registry) => (obj) => new Promise((resolve, reject) => {
+module.exports = (registry) => (obj, parseOptions = null) => new Promise((resolve, reject) => {
   let schemaId;
   
   if (obj.readUInt8(0) !== 0) {
@@ -15,7 +15,7 @@ module.exports = (registry) => (obj) => new Promise((resolve, reject) => {
       return resolve(promise);
     }
 
-    promise = fetchSchema(registry, schemaId);
+    promise = fetchSchema(registry, schemaId, parseOptions);
     
     registry.cache.set(schemaId, promise);
     

--- a/lib/decode-function.js
+++ b/lib/decode-function.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const avsc = require('avsc');
-
 const fetchSchema = require('./fetch-schema');
 
 module.exports = (registry) => (obj) => new Promise((resolve, reject) => {
@@ -26,4 +24,4 @@ module.exports = (registry) => (obj) => new Promise((resolve, reject) => {
       .catch(reject);
 
     return resolve(promise);
-}).then((schema) => avsc.parse(schema).fromBuffer(obj.slice(5)));
+}).then((schema) => schema.fromBuffer(obj.slice(5)));

--- a/lib/encode-function.js
+++ b/lib/encode-function.js
@@ -5,19 +5,19 @@ const avsc = require('avsc');
 const fetchSchema = require('./fetch-schema');
 const pushSchema = require('./push-schema');
 
-const byId = (registry) => (schemaId, msg) => (() => new Promise((resolve, reject) => {
+const byId = (registry) => (schemaId, msg, parseOptions = null) => (() => new Promise((resolve, reject) => {
   let promise = registry.cache.getById(schemaId);
 
   if (promise) {
     return resolve(promise);
   }
 
-  promise = fetchSchema(registry, schemaId);
+  promise = fetchSchema(registry, schemaId, parseOptions);
   
   registry.cache.set(schemaId, promise);
   
   promise
-    .then((result) => registry.cache.set(schemaId, avsc.parse(result)))
+    .then((result) => registry.cache.set(schemaId, result))
     .catch(reject);
 
   return resolve(promise);
@@ -32,9 +32,9 @@ const byId = (registry) => (schemaId, msg) => (() => new Promise((resolve, rejec
   return message;
 });
 
-const bySchema = (type, registry) => (topic, schema, msg) => (() => {
+const bySchema = (type, registry) => (topic, schema, msg, parseOptions = null) => (() => {
   const schemaString = JSON.stringify(schema);
-  const parsedSchema = avsc.parse(schema);
+  const parsedSchema = avsc.parse(schema, parseOptions);
   let id = registry.cache.getBySchema(parsedSchema);
   if (id) {
     return Promise.resolve(id)

--- a/lib/encode-function.js
+++ b/lib/encode-function.js
@@ -17,13 +17,13 @@ const byId = (registry) => (schemaId, msg) => (() => new Promise((resolve, rejec
   registry.cache.set(schemaId, promise);
   
   promise
-    .then((result) => registry.cache.set(schemaId, result))
+    .then((result) => registry.cache.set(schemaId, avsc.parse(result)))
     .catch(reject);
 
   return resolve(promise);
 }))()
 .then((schema) => {
-  const encodedMessage = avsc.parse(schema).toBuffer(msg);
+  const encodedMessage = schema.toBuffer(msg);
 
   const message = Buffer.alloc(encodedMessage.length + 5);
   message.writeUInt8(0);
@@ -34,16 +34,17 @@ const byId = (registry) => (schemaId, msg) => (() => new Promise((resolve, rejec
 
 const bySchema = (type, registry) => (topic, schema, msg) => (() => {
   const schemaString = JSON.stringify(schema);
-  let id = registry.cache.getBySchema(schema);
+  const parsedSchema = avsc.parse(schema);
+  let id = registry.cache.getBySchema(parsedSchema);
   if (id) {
     return Promise.resolve(id)
   }
 
   return pushSchema(registry, topic, schemaString, type)
-    .then(id => registry.cache.set(id, schema));
+    .then(id => registry.cache.set(id, parsedSchema));
 })()
 .then((schemaId) => {
-  const encodedMessage = avsc.parse(schema).toBuffer(msg);
+  const encodedMessage = registry.cache.getById(schemaId).toBuffer(msg);
 
   const message = Buffer.alloc(encodedMessage.length + 5);
   message.writeUInt8(0);

--- a/lib/fetch-schema.js
+++ b/lib/fetch-schema.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const avsc = require('avsc');
+
 module.exports = (registry, schemaId) => new Promise((resolve, reject) => {
   const {protocol, host, port, auth} = registry;
   const requestOptions = {
@@ -23,7 +25,7 @@ module.exports = (registry, schemaId) => new Promise((resolve, reject) => {
       }
 
       const schema = JSON.parse(data).schema;
-      resolve(schema);
+      resolve(avsc.parse(schema));
     });
   });
 });

--- a/lib/fetch-schema.js
+++ b/lib/fetch-schema.js
@@ -2,7 +2,7 @@
 
 const avsc = require('avsc');
 
-module.exports = (registry, schemaId) => new Promise((resolve, reject) => {
+module.exports = (registry, schemaId, parseOptions) => new Promise((resolve, reject) => {
   const {protocol, host, port, auth} = registry;
   const requestOptions = {
     host,
@@ -25,7 +25,7 @@ module.exports = (registry, schemaId) => new Promise((resolve, reject) => {
       }
 
       const schema = JSON.parse(data).schema;
-      resolve(avsc.parse(schema));
+      resolve(avsc.parse(schema, parseOptions));
     });
   });
 });


### PR DESCRIPTION
so it's only called once instead of everytime when decode/encode is called