### PR TITLE
Adding a error handler to the .get() request to handle when registry …

### DIFF
--- a/lib/fetch-schema.js
+++ b/lib/fetch-schema.js
@@ -27,5 +27,7 @@ module.exports = (registry, schemaId, parseOptions) => new Promise((resolve, rej
       const schema = JSON.parse(data).schema;
       resolve(avsc.parse(schema, parseOptions));
     });
+  }).on('error', (e) => {
+    reject(e);
   });
 });

--- a/test/lib/fetch-schema.test.js
+++ b/test/lib/fetch-schema.test.js
@@ -41,6 +41,7 @@ describe('fetchSchema', () => {
     return uut.then((schema) => {
       expect(schema).to.eql(schema);
     });
+  }).on('error', (e) => {
+    reject(e);
   });
 });
-  

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -53,6 +53,15 @@ describe('registry', () => {
 
       return uut.encodeMessage('test', schema, 'some string');
     })
+
+    it('handles connection error', () => {
+      const uut = registry('https://not-good-url');
+
+      const schema = {type: 'string'};
+
+      const result = uut.encodeMessage('test', schema, 'some string');
+      expect(result).to.eventually.be.rejectedWith('getaddrinfo ENOTFOUND not-good-url not-good-url:443');
+    })
   });
 
 });


### PR DESCRIPTION
…is unavailable

We are having an issue where our whole app crashes if the Schema Registry is unavailable. Easily solved by adding a .on('error') handler to the http(s).get() in fetch-shema.js

I've also added a test.

Thanks.