### PR TITLE
Fixes getSchemaByName not defined

### DIFF
--- a/lib/encode-function.js
+++ b/lib/encode-function.js
@@ -67,7 +67,7 @@ const getSchemaByTopicName = (registry) => (topic, parseOptions) => {
   })
 }
 
-const byTopicName = (registry) => (topic, msg, parseOptions = null) => getSchemaByName(registry)(topic, parseOptions).then(({id, parsedSchema}) => encodeMessage(msg, id)(parsedSchema))
+const byTopicName = (registry) => (topic, msg, parseOptions = null) => getSchemaByTopicName(registry)(topic, parseOptions).then(({id, parsedSchema}) => encodeMessage(msg, id)(parsedSchema))
 
 module.exports = {
   bySchema,


### PR DESCRIPTION
I took a quick look and I assume it is meant to call the similarly named `getSchemaByTopicName` which is defined above. Please correct me if I'm wrong. This should solve #26 