### PR TITLE
Add support for Naming Strategies (Issue #28)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,8 +2,14 @@ declare namespace schema {
     export type DecodeMessage = <T>(obj: Buffer, parseOptions?: any) => Promise<T>;
     export type EncodeById = (schemaId: number, msg: any, parseOptions?: any) => Promise<Buffer>;
     export type EncodeBySchema = (topic: string, schema: any, msg: any, parseOptions?: any) => Promise<Buffer>;
+    export type EncodeKeyBySchema = (strategy: string, schema: any, msg: any, parseOptions?: any) => Promise<Buffer>;
+    export type EncodeMessageBySchema = (strategy: string, schema: any, msg: any, parseOptions?: any) => Promise<Buffer>;
     export type EncodeByTopicName = (topic: string, msg: any, parseOptions?: any) => Promise<Buffer>;
-    export type GetSchemaByTopicName = (topic: string, parseOptions?: any) => Promise<{id: number, parsedSchema: any}>;
+    export type EncodeByTopicRecordName = (topic: string, recordName: string, msg: any, parseOptions?: any) => Promise<Buffer>;
+    export type EncodeByRecordName = (recordName: string, msg: any, parseOptions?: any) => Promise<Buffer>;
+    export type GetSchemaByTopicName = (topic: string, parseOptions?: any) => Promise<{ id: number, parsedSchema: any }>;
+    export type GetSchemaByTopicRecordName = (topic: string, recordName: string, parseOptions?: any) => Promise<{ id: number, parsedSchema: any }>;
+    export type GetSchemaByRecordName = (recordName: string, parseOptions?: any) => Promise<{ id: number, parsedSchema: any }>;
 
     export interface ISchemaRegistry {
         decode: DecodeMessage;
@@ -11,8 +17,19 @@ declare namespace schema {
         encodeById: EncodeById;
         encodeKey: EncodeBySchema;
         encodeMessage: EncodeBySchema;
-        encodeMessageByTopicName: EncodeByTopicName
-        getSchemaByTopicName: GetSchemaByTopicName
+        encodeKeyBySchema: EncodeKeyBySchema;
+        encodeMessageBySchema: EncodeMessageBySchema;
+        encodeMessageByTopicName: EncodeByTopicName;
+        encodeMessageByTopicRecordName: EncodeByTopicRecordName;
+        encodeMessageByRecordName: EncodeByRecordName;
+        getSchemaByTopicName: GetSchemaByTopicName;
+        getSchemaByTopicRecordName: GetSchemaByTopicRecordName;
+        getSchemaByRecordName: GetSchemaByRecordName;
+        Strategy: {
+            TopicNameStrategy: string;
+            TopicRecordNameStrategy: string;
+            RecordNameStrategy: string;
+        };
     }
 }
 

--- a/lib/encode-function.js
+++ b/lib/encode-function.js
@@ -5,6 +5,7 @@ const avsc = require('avsc');
 const fetchSchema = require('./fetch-schema');
 const pushSchema = require('./push-schema');
 const getLatestSchema = require('./get-latest-schema-version');
+const { Strategy, getSubject } = require('./strategy');
 
 const encodeMessage = (msg, schemaId) => schema => {
   const encodedMessage = schema.toBuffer(msg);
@@ -36,15 +37,14 @@ const byId = (registry) => (schemaId, msg, parseOptions = null) => (() => new Pr
 }))()
 .then(encodeMessage(msg, schemaId));
 
-const bySchema = (type, registry) => (topic, schema, msg, parseOptions = null) => (() => {
-  const schemaString = JSON.stringify(schema);
+const bySchema = (strategy, isKey, registry) => (topic, schema, msg, parseOptions = null) => (() => {
   const parsedSchema = avsc.parse(schema, parseOptions);
   let id = registry.cache.getBySchema(parsedSchema);
   if (id) {
     return Promise.resolve(id)
   }
 
-  return pushSchema(registry, topic, schemaString, type)
+  return pushSchema(strategy, registry, topic, parsedSchema, isKey)
     .then(id => registry.cache.set(id, parsedSchema));
 })()
 .then(schemaId => {
@@ -53,25 +53,44 @@ const bySchema = (type, registry) => (topic, schema, msg, parseOptions = null) =
   return encodeMessage(msg, schemaId)(schema)
 });
 
-const getSchemaByTopicName = (registry) => (topic, parseOptions) => {
-  const schemaId = registry.cache.getByName(topic);
+const getSchemaByName = (registry, topic, parseOptions, isKey, recordName, strategy) => {
+  const subject = getSubject(strategy, topic, isKey, recordName);
+  const schemaId = registry.cache.getByName(subject);
 
   if (schemaId) {
     return registry.cache.getById(schemaId);
   }
 
-  return getLatestSchema(registry, topic, parseOptions).then(({parsedSchema, id}) => {
+  return getLatestSchema(registry, topic, parseOptions, isKey, recordName, strategy).then(({parsedSchema, id}) => {
     registry.cache.set(id, parsedSchema);
 
     return {id, parsedSchema};
   })
 }
 
+const getSchemaByTopicName = (registry) => (topic, parseOptions) => {
+  return getSchemaByName(registry, topic, parseOptions, false, null, Strategy.TopicNameStrategy);
+}
+
+const getSchemaByTopicRecordName = (registry) => (topic, recordName, parseOptions) => {
+  return getSchemaByName(registry, topic, parseOptions, false, recordName, Strategy.TopicRecordNameStrategy);
+}
+
+const getSchemaByRecordName = (registry) => (recordName, parseOptions) => {
+  return getSchemaByName(registry, null, parseOptions, false, recordName, Strategy.RecordNameStrategy);
+}
+
 const byTopicName = (registry) => (topic, msg, parseOptions = null) => getSchemaByTopicName(registry)(topic, parseOptions).then(({id, parsedSchema}) => encodeMessage(msg, id)(parsedSchema))
+const byTopicRecordName = (registry) => (topic, recordName, msg, parseOptions = null) => getSchemaByTopicRecordName(registry)(topic, recordName, parseOptions).then(({id, parsedSchema}) => encodeMessage(msg, id)(parsedSchema))
+const byRecordName = (registry) => (recordName, msg, parseOptions = null) => getSchemaByRecordName(registry)(recordName, parseOptions).then(({id, parsedSchema}) => encodeMessage(msg, id)(parsedSchema))
 
 module.exports = {
   bySchema,
   byId,
   byTopicName,
-  getSchemaByTopicName
+  byTopicRecordName,
+  byRecordName,
+  getSchemaByTopicName,
+  getSchemaByTopicRecordName,
+  getSchemaByRecordName
 }

--- a/lib/encode-function.js
+++ b/lib/encode-function.js
@@ -26,9 +26,9 @@ const byId = (registry) => (schemaId, msg, parseOptions = null) => (() => new Pr
   }
 
   promise = fetchSchema(registry, schemaId, parseOptions);
-  
+
   registry.cache.set(schemaId, promise);
-  
+
   promise
     .then((result) => registry.cache.set(schemaId, result))
     .catch(reject);
@@ -57,8 +57,10 @@ const getSchemaByName = (registry, topic, parseOptions, isKey, recordName, strat
   const subject = getSubject(strategy, topic, isKey, recordName);
   const schemaId = registry.cache.getByName(subject);
 
-  if (schemaId) {
-    return registry.cache.getById(schemaId);
+  if(schemaId) {
+    return new Promise(resolve =>
+      resolve({ id: schemaId, parsedSchema: registry.cache.getById(schemaId) })
+    );
   }
 
   return getLatestSchema(registry, topic, parseOptions, isKey, recordName, strategy).then(({parsedSchema, id}) => {

--- a/lib/get-latest-schema-version.js
+++ b/lib/get-latest-schema-version.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const avsc = require('avsc');
+const { Strategy, getSubject } = require('./strategy');
 
 const request = (registry, path, method = 'GET', body = null) => {
   return new Promise((resolve, reject) => {
@@ -57,15 +58,18 @@ const request = (registry, path, method = 'GET', body = null) => {
   });
 };
 
-module.exports = (registry, topic, parseOptions = null, type = 'value') => {
+module.exports = (registry, topic, parseOptions = null, isKey, recordName = null, strategy) => {
+
+  const subject = getSubject(strategy, topic, isKey, recordName);
+
   function resolveVersion(versions) {
     return request(
       registry,
-      `subjects/${topic}-${type}/versions/${versions.pop()}`,
+      `subjects/${subject}/versions/${versions.pop()}`,
     );
   }
 
-  return request(registry, `subjects/${topic}-${type}/versions`)
+  return request(registry, `subjects/${subject}/versions`)
     .then(resolveVersion)
     .then(({ id, schema }) => {
       return {

--- a/lib/push-schema.js
+++ b/lib/push-schema.js
@@ -1,13 +1,24 @@
 'use strict';
 
-module.exports = (registry, topic, schemaString, type = 'value') => new Promise((resolve, reject) => {
+const { Strategy, getSubject } = require('./strategy');
+
+module.exports = (strategy, registry, topic, parsedSchema, isKey) => new Promise((resolve, reject) => {
   const { protocol, host, port, path, auth } = registry;
+  const schemaString = JSON.stringify(parsedSchema.toJSON());
+  const recordName = parsedSchema.name;
+  const typeName = parsedSchema.typeName;
   const body = JSON.stringify({schema: schemaString});
+
+  if(strategy !== Strategy.TopicNameStrategy && typeName !== 'record') {
+    throw new Error(`In strategy ${strategy} the schema must only be an Avro record schema`)
+  }
+
+  const subject = getSubject(strategy, topic, isKey, recordName);
   const reqestOptions = {
     host: `${host}`,
     port: port,
     method: 'POST',
-    path: `${path}subjects/${topic}-${type}/versions`,
+    path: `${path}subjects/${subject}/versions`,
     headers: {
       'Content-Type': 'application/vnd.schemaregistry.v1+json',
       'Content-Length': Buffer.byteLength(body),

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const Strategy = {
+  TopicNameStrategy: 'TopicNameStrategy',
+  TopicRecordNameStrategy: 'TopicRecordNameStrategy',
+  RecordNameStrategy: 'RecordNameStrategy'
+};
+
+function getSubject(strategy, topic, isKey, recordName) {
+  switch (strategy) {
+    case Strategy.TopicNameStrategy:
+      return `${topic}-${isKey ? 'key' : 'value'}`;
+    case Strategy.TopicRecordNameStrategy:
+      if(recordName === null) throw new Error("recordName must be set if using TopicRecordNameStrategy");
+      return `${topic}-${recordName}`;
+    case Strategy.RecordNameStrategy:
+      if(recordName === null) throw new Error("recordName must be set if using RecordNameStrategy");
+      return recordName;
+  }
+}
+
+module.exports = {
+  Strategy,
+  getSubject
+};

--- a/registry.js
+++ b/registry.js
@@ -7,6 +7,7 @@ const https = require('https');
 const SchemaCache = require('./lib/schema-cache');
 const decodeFunction = require('./lib/decode-function');
 const encodeFunction = require('./lib/encode-function');
+const { Strategy } = require('./lib/strategy');
 
 function schemas(registryUrl) {
   const parsed = url.parse(registryUrl);
@@ -23,11 +24,20 @@ function schemas(registryUrl) {
   }
 
   const decode = decodeFunction(registry);
-  const encodeKey = encodeFunction.bySchema('key', registry);
-  const encodeMessage = encodeFunction.bySchema('value', registry);
+
+  const encodeKey = encodeFunction.bySchema(Strategy.TopicNameStrategy, true, registry);
+  const encodeMessage = encodeFunction.bySchema(Strategy.TopicNameStrategy, false, registry);
+  const encodeKeyBySchema = (strategy, topic, schema, msg, parseOptions = null) =>
+    encodeFunction.bySchema(strategy, true, registry)(topic, schema, msg, parseOptions);
+  const encodeMessageBySchema = (strategy, topic, schema, msg, parseOptions = null) =>
+    encodeFunction.bySchema(strategy, false, registry)(topic, schema, msg, parseOptions);
   const encodeById = encodeFunction.byId(registry);
   const encodeMessageByTopicName = encodeFunction.byTopicName(registry);
+  const encodeMessageByTopicRecordName = encodeFunction.byTopicRecordName(registry);
+  const encodeMessageByRecordName = encodeFunction.byRecordName(registry);
   const getSchemaByTopicName = encodeFunction.getSchemaByTopicName(registry);
+  const getSchemaByTopicRecordName = encodeFunction.getSchemaByTopicRecordName(registry);
+  const getSchemaByRecordName = encodeFunction.getSchemaByRecordName(registry);
 
   return {
     decode,
@@ -35,8 +45,15 @@ function schemas(registryUrl) {
     encodeById,
     encodeKey,
     encodeMessage,
+    encodeKeyBySchema,
+    encodeMessageBySchema,
     encodeMessageByTopicName,
+    encodeMessageByTopicRecordName,
+    encodeMessageByRecordName,
     getSchemaByTopicName,
+    getSchemaByTopicRecordName,
+    getSchemaByRecordName,
+    Strategy
   };
 }
 

--- a/test/lib/encode-function.test.js
+++ b/test/lib/encode-function.test.js
@@ -10,6 +10,7 @@ chai.use(chaiAsPromised);
 
 const SchemaCache = require('./../../lib/schema-cache');
 const encodeFunction = require('./../../lib/encode-function');
+const { Strategy } = require('./../../lib/strategy');
 
 describe('encodeFunction', () => {
   let registry;
@@ -80,7 +81,7 @@ describe('encodeFunction', () => {
         .post('/subjects/test-key/versions')
         .reply(200, {id: 1});
 
-      const uut = encodeFunction.bySchema('key', registry);
+      const uut = encodeFunction.bySchema(Strategy.TopicNameStrategy, true, registry);
       return uut('test', schema, message).then((encoded) => {
         expect(encoded).to.eql(buffer);
       });
@@ -94,7 +95,7 @@ describe('encodeFunction', () => {
         .post('/subjects/test-value/versions')
         .reply(200, {id: 1});
 
-      const uut = encodeFunction.bySchema('value', registry);
+      const uut = encodeFunction.bySchema(Strategy.TopicNameStrategy, false, registry);
       return uut('test', schema, message).then((encoded) => {
         expect(encoded).to.eql(buffer);
       });
@@ -105,7 +106,7 @@ describe('encodeFunction', () => {
         .post('/subjects/test-key/versions')
         .reply(500, {error_code: 42201, message: 'Invalid Avro schema'});
 
-      const uut = encodeFunction.bySchema('key', registry);
+      const uut = encodeFunction.bySchema(Strategy.TopicNameStrategy, true, registry);
       return uut('test', {type: 'string'}, 'test message').catch((error) => {
         expect(error).to.exist
           .and.be.instanceof(Error)
@@ -121,7 +122,7 @@ describe('encodeFunction', () => {
         .post('/subjects/test-key/versions')
         .reply(200, {id: 1});
 
-      const uut = encodeFunction.bySchema('key', registry);
+      const uut = encodeFunction.bySchema(Strategy.TopicNameStrategy, true, registry);
       return uut('test', schema, message).then((encoded) => {
         expect(encoded).to.eql(buffer);
       });
@@ -135,7 +136,7 @@ describe('encodeFunction', () => {
         .post('/subjects/test-key/versions')
         .reply(200, {id: 1});
 
-      const uut = encodeFunction.bySchema('key', registry);
+      const uut = encodeFunction.bySchema(Strategy.TopicNameStrategy, true, registry);
       return uut('test', schema, message).then((encoded1) => {
         expect(encoded1).to.eql(buffer);
         return uut('test', schema, message).then((encoded2) => {


### PR DESCRIPTION
Adds support for the different subject name strategies provided from confluent:

- ``TopicNameStrategy`` (the one currently supported)
   Subject: `${topic}-${isKey ? 'key' : 'value'}`
- ``TopicRecordNameStrategy``
   Subject: `${topic}-${recordName}`
- ``RecordNameStrategy``
   Subject: `recordName`

Adds the following functions:
```
        encodeKeyBySchema: (strategy: string, schema: any, msg: any, parseOptions?: any) => Promise<Buffer>
        encodeMessageBySchema: (strategy: string, schema: any, msg: any, parseOptions?: any) => Promise<Buffer>
        encodeMessageByTopicRecordName: (topic: string, recordName: string, msg: any, parseOptions?: any) => Promise<Buffer>
        encodeMessageByRecordName: (recordName: string, msg: any, parseOptions?: any) => Promise<Buffer>
        getSchemaByTopicRecordName: (topic: string, recordName: string, parseOptions?: any) => Promise<{ id: number, parsedSchema: any }>
        getSchemaByRecordName: (recordName: string, parseOptions?: any) => Promise<{ id: number, parsedSchema: any }>
```

Strategy constants can be accessed via the registry object e.g. `registry.Strategy.RecordNameStrategy`.

All existing functions fall back to `TopicNameStrategy` to be backwards compatible.

I fixed the existing tests but did not write some for the new functions, i also have not updated the readme.