### PR TITLE
destructuring URL constructor from node url module

### DIFF
--- a/registry.js
+++ b/registry.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const url = require('url');
+const { URL } = require('url');
 const http = require('http');
 const https = require('https');
 


### PR DESCRIPTION
Fixes a small issue for node versions < 10 where the URL class of the WHATWG URL API is not available on the global object. Starting from node v10.0.0, the URL class is available in the global object, which means that you are not required to import the `url` module. However, previous versions of node still require this import.