### PR TITLE
Remove unused variable

### DIFF
--- a/registry.js
+++ b/registry.js
@@ -97,8 +97,6 @@ const getSchema = (id, parseOptions) => {
     const id = msg.readUInt32BE(1);
     const buffer = msg.slice(5);
 
-    const schema = registry.cache.getById(id);
-
     let schemaPromise = registry.cache.getById(id);
     if (!schemaPromise) {
       schemaPromise = getSchemaById(registry, id);


### PR DESCRIPTION
Inside of function "decode" in registry.js
There was an unused variable.
It was removed