### PR TITLE
Properly support URLs with paths in them

### DIFF
--- a/registry.js
+++ b/registry.js
@@ -16,7 +16,7 @@ function schemas(registryUrl, auth = null) {
     protocol: parsed.protocol.startsWith('https') ? https : http,
     host: parsed.hostname,
     port: parsed.port,
-    path: parsed.path != null ? parsed.path : '/',
+    path: parsed.pathname != null ? parsed.pathname : '/',
     username: parsed.username,
     password: parsed.password,
   };

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -70,6 +70,17 @@ describe('registry', () => {
       return uut.encodeMessage('test', schema, 'some string');
     });
 
+    it('correctly handles URLs with paths', () => {
+      const uut = registry('https://test.com/schemaregistry/');
+
+      const schema = {type: 'string'};
+      nock('https://test.com')
+        .post('/schemaregistry/subjects/test-value/versions')
+        .reply(200, {id: 1});
+
+      return uut.encodeMessage('test', schema, 'some string');
+    });
+
     it('handles connection error', () => {
       const uut = registry('https://not-good-url');
 


### PR DESCRIPTION
The library was grabbing the wrong property from the parsed URL and would always find it null, so it would not support schema registry URLs with paths in them.


```
  http-calls
    pushSchema
      ✓ reject if post request fails
      ✓ reject if post request returns with not 200
      ✓ resolve with schema id if post request returns with 200
    getSchemaById
      ✓ reject if get request fails
      ✓ reject if get request returns with not 200
      ✓ resolve with schema if get request returns with 200
    getLatestVersionForSubject
      ✓ reject if first get request fails
      ✓ reject if first get request returns with not 200
      ✓ reject if second get request fails
      ✓ reject if second get request returns with not 200
      ✓ resolve with schema and id if both get requests return with 200

  schema-cache
    setById
      ✓ updates the cache
    setByName
      ✓ updates the cache
    setBySchema
      ✓ updates the cache

  registry
    export
      ✓ returns an object with encode and decode methods
      ✓ selects https transport
      ✓ respects basic auth credentials from the url
      ✓ respects basic auth credentials from the auth object
      ✓ correctly handles URLs with paths
      ✓ handles connection error
    decode
      ✓ rejects if the message doesn't contain a magic byte
      ✓ rejects if the registry call fails
      ✓ uses the registry for the first call and cache for the second call for the same id
    encodeKey
      ✓ rejects if the schema parse fails
      ✓ rejects if the schema registry call fails
      ✓ uses the registry for the first call to register schema and return id and cache for the second call for the same schema
    encodeMessage
      ✓ rejects if the schema parse fails
      ✓ rejects if the schema registry call fails
      ✓ uses the registry for the first call to register schema and return id and cache for the second call for the same schema
    encodeById
      ✓ rejects if the schema registry call fails
      ✓ uses the registry for the first call and cache for the second call for the same id
    encodeMessageByTopicName
      ✓ rejects if the schema registry call fails
      ✓ uses the registry for the first call and cache for the second call for the same topic name
    getSchemaByTopicName
      ✓ rejects if the schema registry call fails
      ✓ uses the registry for the first call and cache for the second call for the same topic name


  35 passing (223ms)
```